### PR TITLE
feat(rec): add new crate `tracing-rec`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "itoa"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,6 +70,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+
+[[package]]
+name = "serde"
+version = "1.0.196"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.196"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.113"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -143,6 +186,16 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-rec"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
 
 [workspace]
 resolver = "2"
-members = ["tracing-replay"]
+members = [ "tracing-rec","tracing-replay"]

--- a/tracing-rec/Cargo.toml
+++ b/tracing-rec/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "tracing-rec"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+tracing = "0.1"
+tracing-subscriber = "0.3"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1.0"

--- a/tracing-rec/examples/events.rs
+++ b/tracing-rec/examples/events.rs
@@ -1,0 +1,22 @@
+use tracing_subscriber::prelude::*;
+
+fn main() {
+    tracing_subscriber::registry()
+        .with(tracing_rec::rec_layer())
+        .init();
+
+    tracing::info!("I am an info event!");
+
+    tracing::error!(parent: None, broken = true, "I have a field!");
+
+    let span: tracing::Span = tracing::info_span!("span");
+    span.in_scope(|| {
+        tracing::debug!(working = true, "Message with interpolated value: {}", 42);
+    });
+
+    tracing::warn!(parent: span, "Event with explicit parent");
+
+    for idx in 0..3 {
+        tracing::trace!(idx, "Event in a loop");
+    }
+}

--- a/tracing-rec/src/lib.rs
+++ b/tracing-rec/src/lib.rs
@@ -1,0 +1,209 @@
+use std::io::{stdout, Write};
+
+use serde::Serialize;
+use tracing::{field::Visit, span, subscriber::Interest, Subscriber};
+
+pub struct Rec;
+
+#[must_use]
+pub fn rec_layer() -> Rec {
+    Rec {}
+}
+
+#[derive(Debug, Serialize)]
+enum Trace {
+    RegisterCallsite(Metadata),
+    Event(Event),
+}
+
+#[derive(Debug, Serialize)]
+enum Level {
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+impl From<&tracing::Level> for Level {
+    fn from(value: &tracing::Level) -> Self {
+        match *value {
+            tracing::Level::TRACE => Level::Trace,
+            tracing::Level::DEBUG => Level::Debug,
+            tracing::Level::INFO => Level::Info,
+            tracing::Level::WARN => Level::Warn,
+            tracing::Level::ERROR => Level::Error,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+enum Kind {
+    Span,
+    Event,
+}
+
+impl From<&'static tracing::Metadata<'static>> for Kind {
+    fn from(value: &'static tracing::Metadata<'static>) -> Self {
+        if value.is_event() {
+            Self::Event
+        } else {
+            debug_assert!(
+                value.is_span(),
+                "either is_event() or is_span() should be true",
+            );
+            Self::Span
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct Metadata {
+    id: u64,
+    name: &'static str,
+    target: &'static str,
+    level: Level,
+    module_path: Option<&'static str>,
+    file: Option<&'static str>,
+    line: Option<u32>,
+    fields: Vec<&'static str>,
+    kind: Kind,
+}
+
+impl From<&'static tracing::Metadata<'static>> for Metadata {
+    fn from(value: &'static tracing::Metadata<'static>) -> Self {
+        Self {
+            id: value as *const _ as u64,
+            name: value.name(),
+            target: value.target(),
+            level: value.level().into(),
+            module_path: value.module_path(),
+            file: value.file(),
+            line: value.line(),
+            fields: value.fields().iter().map(|f| f.name()).collect(),
+            kind: Kind::from(value),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+enum Parent {
+    /// The new span will be a root span.
+    Root,
+    /// The new span will be rooted in the current span.
+    Current,
+    /// The new span has an explicitly-specified parent.
+    Explicit(u64),
+}
+
+impl From<&tracing::Event<'_>> for Parent {
+    fn from(value: &tracing::Event<'_>) -> Self {
+        if value.is_root() {
+            Self::Root
+        } else if value.is_contextual() {
+            Self::Current
+        } else {
+            Self::Explicit(
+                value
+                    .parent()
+                    .expect("a span that isn't root or contextual should have an explicit Id")
+                    .into_u64(),
+            )
+        }
+    }
+}
+#[derive(Debug, Serialize)]
+struct Event {
+    fields: Vec<(&'static str, String)>,
+    metadata: Metadata,
+    parent: Parent,
+}
+
+impl From<&tracing::Event<'_>> for Event {
+    fn from(value: &tracing::Event<'_>) -> Self {
+        let mut event = Self {
+            fields: Vec::new(),
+            metadata: value.metadata().into(),
+            parent: Parent::from(value),
+        };
+        value.record(&mut event);
+
+        event
+    }
+}
+
+impl Visit for Event {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        self.fields.push((field.name(), format!("{value:?}")));
+    }
+}
+
+impl<S> tracing_subscriber::Layer<S> for Rec
+where
+    S: Subscriber,
+{
+    fn register_callsite(&self, metadata: &'static tracing::Metadata<'static>) -> Interest {
+        let trace = Trace::RegisterCallsite(metadata.into());
+        serde_json::to_writer(stdout(), &trace).expect("writing failed");
+        stdout().write_all(b"\n").expect("writing failed");
+
+        Interest::always()
+    }
+
+    fn on_new_span(
+        &self,
+        attrs: &span::Attributes<'_>,
+        id: &span::Id,
+        ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        let _ = (attrs, id, ctx);
+    }
+
+    fn on_record(
+        &self,
+        _span: &span::Id,
+        _values: &span::Record<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+    }
+
+    fn on_follows_from(
+        &self,
+        _span: &span::Id,
+        _follows: &span::Id,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+    }
+
+    fn event_enabled(
+        &self,
+        _event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) -> bool {
+        true
+    }
+
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        let trace = Trace::Event(event.into());
+        serde_json::to_writer(stdout(), &trace).expect("writing failed");
+        stdout().write_all(b"\n").expect("writing failed");
+    }
+
+    fn on_enter(&self, _id: &span::Id, _ctx: tracing_subscriber::layer::Context<'_, S>) {}
+
+    fn on_exit(&self, _id: &span::Id, _ctx: tracing_subscriber::layer::Context<'_, S>) {}
+
+    fn on_close(&self, _id: span::Id, _ctx: tracing_subscriber::layer::Context<'_, S>) {}
+
+    fn on_id_change(
+        &self,
+        _old: &span::Id,
+        _new: &span::Id,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+    }
+}


### PR DESCRIPTION
This is the initial (incomplete) implementation of the `tracing-rec`
crate. This crate provides a `tracing-subscriber` layer which will
record (hence "rec") traces it receives.

The idea is to record data as close as possible to what the layer
receives and then serialize it into a format that can later be read by
`tracing-replay` and replayed (hence "replay") into a `tracing`
dispatcher.

The initial implementation records calls to `Layer::register_callsite`
and `Layer::on_event`. The contents are then serialized into JSON
(because it allows easy visual debugging) and written to `stdout`.

An example called `events` is also included which records some events
(and a span to show the parent field) which are then output by the `Rec`
layer.