### PR TITLE
feat(rec): add support for recording spans

### DIFF
--- a/tracing-rec/examples/spans.rs
+++ b/tracing-rec/examples/spans.rs
@@ -1,0 +1,36 @@
+use tracing_subscriber::prelude::*;
+
+fn main() {
+    tracing_subscriber::registry()
+        .with(tracing_rec::rec_layer())
+        .init();
+
+    let info_span = tracing::info_span!("info-span", value_will_change = 15);
+    let _info_guard = info_span.enter();
+
+    let enter_later = tracing::error_span!("enter-later");
+    enter_later.follows_from(&info_span);
+
+    let _later_guard = {
+        let _direct_guard = tracing::warn_span!("direct-enter", wonderful = 42).entered();
+        tracing::info!("an event");
+
+        let later_guard = enter_later.enter();
+        tracing::info!("I am an info event!");
+
+        later_guard
+    };
+
+    loopy(3);
+
+    info_span.record("value_will_change", 23);
+}
+
+#[tracing::instrument]
+fn loopy(len: usize) {
+    let enter_exit_span = tracing::debug_span!("enter-and-exit");
+    for idx in 0..len {
+        let _guard = enter_exit_span.enter();
+        tracing::trace!(idx, "Event in a loop");
+    }
+}

--- a/tracing-rec/src/lib.rs
+++ b/tracing-rec/src/lib.rs
@@ -1,19 +1,27 @@
-use std::io::{stdout, Write};
+use std::io::{stdout, Stdout, Write};
 
 use serde::Serialize;
 use tracing::{field::Visit, span, subscriber::Interest, Subscriber};
 
-pub struct Rec;
+pub struct Rec {
+    writer: Stdout,
+}
 
 #[must_use]
 pub fn rec_layer() -> Rec {
-    Rec {}
+    Rec { writer: stdout() }
 }
 
 #[derive(Debug, Serialize)]
 enum Trace {
     RegisterCallsite(Metadata),
     Event(Event),
+    NewSpan(NewSpan),
+    Enter(SpanId),
+    Exit(SpanId),
+    Close(SpanId),
+    Record(RecordValues),
+    FollowsFrom(FollowsFrom),
 }
 
 #[derive(Debug, Serialize)]
@@ -112,6 +120,24 @@ impl From<&tracing::Event<'_>> for Parent {
         }
     }
 }
+
+impl From<&span::Attributes<'_>> for Parent {
+    fn from(value: &span::Attributes<'_>) -> Self {
+        if value.is_root() {
+            Self::Root
+        } else if value.is_contextual() {
+            Self::Current
+        } else {
+            Self::Explicit(
+                value
+                    .parent()
+                    .expect("a span that isn't root or contextual should have an explicit Id")
+                    .into_u64(),
+            )
+        }
+    }
+}
+
 #[derive(Debug, Serialize)]
 struct Event {
     fields: Vec<(&'static str, String)>,
@@ -138,6 +164,89 @@ impl Visit for Event {
     }
 }
 
+#[derive(Debug, Serialize)]
+struct NewSpan {
+    id: SpanId,
+    fields: Vec<(&'static str, String)>,
+    metadata: Metadata,
+    parent: Parent,
+}
+
+impl From<(&span::Attributes<'_>, &span::Id)> for NewSpan {
+    fn from((attrs, id): (&span::Attributes<'_>, &span::Id)) -> Self {
+        let mut new_span = Self {
+            id: id.into(),
+            fields: Vec::new(),
+            metadata: attrs.metadata().into(),
+            parent: Parent::from(attrs),
+        };
+        attrs.record(&mut new_span);
+
+        new_span
+    }
+}
+
+impl Visit for NewSpan {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        self.fields.push((field.name(), format!("{value:?}")));
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct SpanId(u64);
+
+impl From<&span::Id> for SpanId {
+    fn from(value: &span::Id) -> Self {
+        Self(value.into_u64())
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct RecordValues {
+    id: SpanId,
+    fields: Vec<(&'static str, String)>,
+}
+
+impl From<(&span::Id, &span::Record<'_>)> for RecordValues {
+    fn from((id, values): (&span::Id, &span::Record<'_>)) -> Self {
+        let mut record_values = Self {
+            id: id.into(),
+            fields: Vec::new(),
+        };
+        values.record(&mut record_values);
+
+        record_values
+    }
+}
+
+impl Visit for RecordValues {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        self.fields.push((field.name(), format!("{value:?}")));
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct FollowsFrom {
+    cause_id: SpanId,
+    effect_id: SpanId,
+}
+
+impl FollowsFrom {
+    fn new(cause_id: SpanId, effect_id: SpanId) -> Self {
+        Self {
+            cause_id,
+            effect_id,
+        }
+    }
+}
+
+impl Rec {
+    fn write_trace(&self, trace: &Trace) {
+        serde_json::to_writer(&self.writer, &trace).expect("writing failed");
+        writeln!(&self.writer).expect("writing failed");
+    }
+}
+
 impl<S> tracing_subscriber::Layer<S> for Rec
 where
     S: Subscriber,
@@ -154,33 +263,30 @@ where
         &self,
         attrs: &span::Attributes<'_>,
         id: &span::Id,
-        ctx: tracing_subscriber::layer::Context<'_, S>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
     ) {
-        let _ = (attrs, id, ctx);
+        let trace = Trace::NewSpan((attrs, id).into());
+        self.write_trace(&trace);
     }
 
     fn on_record(
         &self,
-        _span: &span::Id,
-        _values: &span::Record<'_>,
+        span: &span::Id,
+        values: &span::Record<'_>,
         _ctx: tracing_subscriber::layer::Context<'_, S>,
     ) {
+        let trace = Trace::Record((span, values).into());
+        self.write_trace(&trace);
     }
 
     fn on_follows_from(
         &self,
-        _span: &span::Id,
-        _follows: &span::Id,
+        span: &span::Id,
+        follows: &span::Id,
         _ctx: tracing_subscriber::layer::Context<'_, S>,
     ) {
-    }
-
-    fn event_enabled(
-        &self,
-        _event: &tracing::Event<'_>,
-        _ctx: tracing_subscriber::layer::Context<'_, S>,
-    ) -> bool {
-        true
+        let trace = Trace::FollowsFrom(FollowsFrom::new(follows.into(), span.into()));
+        self.write_trace(&trace);
     }
 
     fn on_event(
@@ -189,21 +295,21 @@ where
         _ctx: tracing_subscriber::layer::Context<'_, S>,
     ) {
         let trace = Trace::Event(event.into());
-        serde_json::to_writer(stdout(), &trace).expect("writing failed");
-        stdout().write_all(b"\n").expect("writing failed");
+        self.write_trace(&trace);
     }
 
-    fn on_enter(&self, _id: &span::Id, _ctx: tracing_subscriber::layer::Context<'_, S>) {}
+    fn on_enter(&self, id: &span::Id, _ctx: tracing_subscriber::layer::Context<'_, S>) {
+        let trace = Trace::Enter(id.into());
+        self.write_trace(&trace);
+    }
 
-    fn on_exit(&self, _id: &span::Id, _ctx: tracing_subscriber::layer::Context<'_, S>) {}
+    fn on_exit(&self, id: &span::Id, _ctx: tracing_subscriber::layer::Context<'_, S>) {
+        let trace = Trace::Exit(id.into());
+        self.write_trace(&trace);
+    }
 
-    fn on_close(&self, _id: span::Id, _ctx: tracing_subscriber::layer::Context<'_, S>) {}
-
-    fn on_id_change(
-        &self,
-        _old: &span::Id,
-        _new: &span::Id,
-        _ctx: tracing_subscriber::layer::Context<'_, S>,
-    ) {
+    fn on_close(&self, id: span::Id, _ctx: tracing_subscriber::layer::Context<'_, S>) {
+        let trace = Trace::Close((&id).into());
+        self.write_trace(&trace);
     }
 }


### PR DESCRIPTION
As well as recording events, we wish to record spans.

Extends the `tracing-rec` crate to also support recording spans. This
completes the implementation of all the methods on `Layer` which are
needed to reproduce the same sequence of traces elsewhere.

A new example, `spans`, has also been added so that all the methods on
`Layer` are invoked between that and the already existing `events`
example.