### PR TITLE
feat(rec): add recording metadata

### DIFF
--- a/tracing-rec/examples/threads.rs
+++ b/tracing-rec/examples/threads.rs
@@ -1,0 +1,35 @@
+use std::{thread, time::Duration};
+
+use tracing_subscriber::prelude::*;
+
+fn main() {
+    tracing_subscriber::registry()
+        .with(tracing_rec::rec_layer())
+        .init();
+
+    let jh = std::thread::Builder::new()
+        .name("other-thread".into())
+        .spawn(move || {
+            let span = tracing::info_span!("other-span");
+            thread::sleep(Duration::from_millis(100));
+            {
+                let _entered = span.enter();
+                tracing::info!("Hi there, it's a bit later");
+                thread::sleep(Duration::from_millis(100));
+            }
+        })
+        .unwrap();
+
+    thread::sleep(Duration::from_millis(50));
+    let span: tracing::Span = tracing::info_span!("span");
+
+    {
+        let _entered = span.enter();
+
+        thread::sleep(Duration::from_millis(100));
+
+        tracing::info!("I am an info event in which thread?");
+    }
+
+    _ = jh.join();
+}


### PR DESCRIPTION
As well as the information required to reproduce a traces, certain
metadata is required so that the reproduced traces behave correctly. As
no context information (current active span) is recorded, it is
important that the traces are recreated in threads which also mimic the
threads in the original recording.

This change embeds the `Trace` enum in a `TraceRecord` struct which also
contains `RecordMeta`. The metadata contains a timestamp as well as the
thread ID (as a debug string, which is the only API that `stable`
offers) and the name of the thread.

This will give `tracing-replay` enough information to reproduce the
context for each trace.

A new example called `threads` has also been added which interleaves
spans and events in 2 different threads.